### PR TITLE
Add drone ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,10 @@
+kind: pipeline
+name: default
+
+steps:
+  - name: check documentation build
+    image: rust:1.49-slim-buster
+    commands:
+      - cargo install mdbook --git https://github.com/Nutomic/mdBook.git --branch localization
+            --rev 0982a82 --force --debug
+      - mdbook build .


### PR DESCRIPTION
Lets do the CI directly in this repo, so it doesnt have to run for every single commit in the Lemmy repo. We should remove it there after merging this PR.