### PR TITLE
Clarify TLS for Docker Documentation

### DIFF
--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -51,6 +51,7 @@ You will also need to setup TLS, for example with [Let's Encrypt](https://letsen
 
 ## Cerbot on NGINX
 
+View: [https://certbot.eff.org/instructions](https://certbot.eff.org/instructions)
 
 Install Certbot on Debian/Ubuntu: 
 ```

--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -21,6 +21,7 @@ Open up your `docker-compose.yml`, and make sure `LEMMY_EXTERNAL_HOST` for `lemm
 ```
 - LEMMY_INTERNAL_HOST=lemmy:8536
 - LEMMY_EXTERNAL_HOST=your-domain.com
+```
 
 You may also want to disable HTTPS for local development:
 

--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -21,6 +21,10 @@ Open up your `docker-compose.yml`, and make sure `LEMMY_EXTERNAL_HOST` for `lemm
 ```
 - LEMMY_INTERNAL_HOST=lemmy:8536
 - LEMMY_EXTERNAL_HOST=your-domain.com
+
+You may also want to disable HTTPS for local development:
+
+```
 - LEMMY_HTTPS=false
 ```
 
@@ -43,6 +47,27 @@ sudo mv nginx.conf /etc/nginx/sites-enabled/lemmy.conf
 ```
 
 You will also need to setup TLS, for example with [Let's Encrypt](https://letsencrypt.org/). After this you need to restart Nginx to reload the config.
+
+## Cerbot on NGINX
+
+
+Install Certbot on Debian/Ubuntu: 
+```
+sudo apt install certbot nginx 
+```
+
+then run:
+
+```
+sudo systemctl stop nginx
+sudo certbot certonly --standalone --post-hook "systemctl restart nginx"
+```
+
+Follow instructions, and finally restart NGINX:
+
+```
+sudo systemctl reload nginx
+```
 
 ## Updating
 


### PR DESCRIPTION
Add documentation on HTTPS, what the varriable means and how to use Certbot.