### PR TITLE
Add yunohost installation method

### DIFF
--- a/src/en/administration/administration.md
+++ b/src/en/administration/administration.md
@@ -18,4 +18,5 @@ Lemmy uses roughly 150 MB of RAM in the default Docker installation. CPU usage i
 
 In some cases, it might be necessary to use different installation methods. But we don't recommend this, and can't provide support for them.
 - [From Scratch](from_scratch.md)
+- [Yunohost](https://install-app.yunohost.org/?app=lemmy) ([source code](https://github.com/YunoHost-Apps/lemmy_ynh))
 - [On Amazon Web Services (AWS)](on_aws.md)


### PR DESCRIPTION
Lemmy is also listed in their [application catalog](https://yunohost.org/en/apps), but its not possible to link to a specific item there, and the documentation link is broken.