### PR TITLE
Add mdbook-linkcheck

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,11 +9,12 @@ steps:
       - git submodule update --recursive --remote
 
   - name: check documentation build
-    image: rust:1.61-slim-buster
+    image: michaelfbryan/mdbook-docker-image:latest
     commands:
+      - apt-get update
+      - apt-get install git cargo -y
       - cargo install mdbook --git https://github.com/Ruin0x11/mdBook.git --branch localization
             --rev 9d8147c --force --debug
-      - apt-get update
-      - apt-get install git -y
       - ./update-includes.sh
+      - echo "\n\n[output.html]\n\n[output.linkcheck]" >> "book.toml"
       - mdbook build .


### PR DESCRIPTION
Currently blocked by https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/71

Its a bit annyoing that there seems to be no option to disable the link check for local builds. I was hoping to run it only in CI, but apparently its also mandatory to install for local development.