### PR TITLE
Upgrade Rust to 1.61.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
       - git submodule update --recursive --remote
 
   - name: check documentation build
-    image: rust:1.56-slim-buster
+    image: rust:1.61-slim-buster
     commands:
       - cargo install mdbook --git https://github.com/Ruin0x11/mdBook.git --branch localization
             --rev 9d8147c --force --debug


### PR DESCRIPTION
To fix CI error: "package `handlebars v4.3.0` cannot be built because it requires rustc 1.57 or newer, while the currently active rustc version is 1.56.1"