### PR TITLE
Fix lemmy.hjson & docker-compose.yml URLs in Docker installation instructions

### DIFF
--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -9,7 +9,7 @@ cd /lemmy
 
 # download default config files
 wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/lemmy.hjson
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/lemmy.hjson
 
 # Set correct permissions for pictrs folder
 mkdir -p volumes/pictrs

--- a/src/es/administration/install_docker.md
+++ b/src/es/administration/install_docker.md
@@ -8,9 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # descarga los archivos de la configuración por defecto
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/iframely.config.local.js
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/lemmy.hjson
 
 # Establece los permisos correctos para la carpeta pictrs
 mkdir -p volumes/pictrs

--- a/src/fr/administration/install_docker.md
+++ b/src/fr/administration/install_docker.md
@@ -8,9 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # télécharger les fichiers de configuration par défaut
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/iframely.config.local.js
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/lemmy.hjson
 
 # Définir les permissions correctes pour le dossier pictrs
 mkdir -p volumes/pictrs

--- a/src/id/administration/install_docker.md
+++ b/src/id/administration/install_docker.md
@@ -8,8 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # unduh berkas konfigurasi baku
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/lemmy.hjson
 
 # atur izin yang benar untuk folder pictrs
 mkdir -p volumes/pictrs

--- a/src/ru/administration/install_docker.md
+++ b/src/ru/administration/install_docker.md
@@ -8,9 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # загрузите кнфигурацию по умолчанию
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/iframely.config.local.js
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/lemmy.hjson
 
 # Установите корректные разрешения для каталога pictrs
 mkdir -p volumes/pictrs


### PR DESCRIPTION
This also removes references to iframely.config.local.js that exist in some of the translations, but are no longer present in the English version.