### PR TITLE
Update from scratch instructions to use embedded pictrs

### DIFF
--- a/src/en/contributing/local_development.md
+++ b/src/en/contributing/local_development.md
@@ -5,7 +5,7 @@ Install Rust using [the recommended option on rust-lang.org](https://www.rust-la
 
 #### Debian-based distro
 ```
-sudo apt install git cargo libssl-dev pkg-config libpq-dev yarn curl gnupg2 espeak
+sudo apt install git cargo libssl-dev pkg-config libpq-dev curl
 # install yarn
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
@@ -14,7 +14,7 @@ sudo apt update && sudo apt install yarn
 
 #### Arch-based distro
 ```
-sudo pacman -S git cargo libssl-dev pkg-config libpq-dev yarn curl gnupg2 espeak
+sudo pacman -S git cargo libssl-dev pkg-config libpq-dev curl
 # install yarn (stable)
 curl -o- -L https://yarnpkg.com/install.sh | bash
 ```


### PR DESCRIPTION
Would be good if someone who uses native install could test this once the release candidate is on crates.io. 

I also changed the dependencies as some of them arent needed anymore.