### PR TITLE
Fixing v0.17 install instructions.

### DIFF
--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -8,8 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # download default config files
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.16/docker/lemmy.hjson
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.17/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.17/docker/lemmy.hjson
 
 # Set correct permissions for pictrs folder
 mkdir -p volumes/pictrs


### PR DESCRIPTION
The current install instructions are referencing the wrong version.