### PR TITLE
Correct typo from Spanish translation

### DIFF
--- a/src/es/SUMMARY.md
+++ b/src/es/SUMMARY.md
@@ -19,7 +19,7 @@
   - [Recursos](federation/resources.md)
   - [Protocolo de Lemmy](federation/lemmy_protocol.md)
 - [Desarrollo de clientes](client_development/client_development.md)
-  - [Guiá para Temas](client_development/theming.md)
+  - [Guía para Temas](client_development/theming.md)
   - [Referencia de la API](client_development/api_reference.md)
   - [API del WebSocket](client_development/websocket_api.md)
   - [API HTTP](client_development/http_api.md)


### PR DESCRIPTION
It's a small typo. [*Guía*](https://es.wiktionary.org/wiki/gu%C3%ADa) is the correct spelling.