### PR TITLE
check for typos in ci

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -21,9 +21,10 @@ pipeline:
   check_typos:
     image: rust:1.70-slim-buster
     commands:
+      - rustc --version #check rust version
       - rustup update # trying this because it says rust version is old
-      - cargo install typos-cli
-      - typos src/en
+#       - cargo install typos-cli
+#       - typos src/en
 
   check_documentation_build:
     image: rust:1.61-slim-buster

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,7 +19,7 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: rust:1.70-slim-buster
+    image: rust:1.70-buster
     commands:
       - rustc --version #check rust version
       - rustup update # trying this because it says rust version is old

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,7 +19,7 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: rust:1.61-slim-buster
+    image: rust:1.70-slim-buster
     commands:
       - cargo install typos-cli
       - typos src/en

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -27,6 +27,12 @@ pipeline:
       - ./update-includes.sh
       - mdbook build .
 
+  check_typos:
+    image: rust:1.61-slim-buster
+    commands:
+      - cargo install typos-cli
+      - typos src/en
+
   dead_links:
     image: becheran/mlc:latest
     commands:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,10 +19,11 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: rust:1.70-slim-bookworm
+    image: apline:3
     commands:
-      - cargo install typos-cli
-      - typos src/en
+      - curl -o typos.tar.gz https://github.com/crate-ci/typos/releases/download/v1.14.12/typos-v1.14.12-x86_64-unknown-linux-musl.tar.gz
+      - tar -xzf typos.tar.gz
+      - ./typos src/en
 
   check_documentation_build:
     image: rust:1.61-slim-buster

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -21,7 +21,6 @@ pipeline:
   check_typos:
     image: imunew/typos-cli
     commands:
-      - rustc --version #check rust version
       - typos src/en
 
   check_documentation_build:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -12,10 +12,17 @@ pipeline:
         #- git fetch --tags
       - git submodule init
       - git submodule update --recursive --remote
+
   check_formatting:
     image: tmknom/prettier
     commands:
       - prettier -c src
+
+  check_typos:
+    image: rust:1.61-slim-buster
+    commands:
+      - cargo install typos-cli
+      - typos src/en
 
   check_documentation_build:
     image: rust:1.61-slim-buster
@@ -26,12 +33,6 @@ pipeline:
       - apt-get install git curl -y
       - ./update-includes.sh
       - mdbook build .
-
-  check_typos:
-    image: rust:1.61-slim-buster
-    commands:
-      - cargo install typos-cli
-      - typos src/en
 
   dead_links:
     image: becheran/mlc:latest

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -21,6 +21,7 @@ pipeline:
   check_typos:
     image: rust:1.70-slim-buster
     commands:
+      - rustup update # trying this because it says rust version is old
       - cargo install typos-cli
       - typos src/en
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,8 +19,9 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: imunew/typos-cli
+    image: rust:1.70-slim-buster
     commands:
+      - cargo install typos-cli@1.14.3
       - typos src/en
 
   check_documentation_build:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,9 +19,9 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: rust:1.70-slim-buster
+    image: rust:1.70-slim-bookworm
     commands:
-      - cargo install typos-cli@1.14.3
+      - cargo install typos-cli
       - typos src/en
 
   check_documentation_build:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -21,7 +21,7 @@ pipeline:
   check_typos:
     image: alpine:3
     commands:
-      - curl -o typos.tar.gz https://github.com/crate-ci/typos/releases/download/v1.14.12/typos-v1.14.12-x86_64-unknown-linux-musl.tar.gz
+      - wget -O typos.tar.gz https://github.com/crate-ci/typos/releases/download/v1.14.12/typos-v1.14.12-x86_64-unknown-linux-musl.tar.gz
       - tar -xzf typos.tar.gz
       - ./typos src/en
 

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,12 +19,10 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: rust:1.70-buster
+    image: imunew/typos-cli
     commands:
       - rustc --version #check rust version
-      - rustup update # trying this because it says rust version is old
-#       - cargo install typos-cli
-#       - typos src/en
+      - typos src/en
 
   check_documentation_build:
     image: rust:1.61-slim-buster

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -19,7 +19,7 @@ pipeline:
       - prettier -c src
 
   check_typos:
-    image: apline:3
+    image: alpine:3
     commands:
       - curl -o typos.tar.gz https://github.com/crate-ci/typos/releases/download/v1.14.12/typos-v1.14.12-x86_64-unknown-linux-musl.tar.gz
       - tar -xzf typos.tar.gz

--- a/src/en/introduction.md
+++ b/src/en/introduction.md
@@ -8,7 +8,7 @@ A Lemmy website can operate alone. Just like a traditional website, people sign 
 
 Lemmy uses a standardized, open protocol to implement federation which is called ActivityPub. Any software that likewise implements federation via ActivityPub can seamlessly communicate with Lemmy, just like Lemmy instances communicate with one another.
 
-The fediverse ("federated universe") is the name for all instances that can communicate with each other over ActivityPub and the World Wide Web. That includes all Lemmy servers, but also other implementations:
+The fediverse ("federated universe") is teh name for all instances that can communicate with each other over ActivityPub and the World Wide Web. That includes all Lemmy servers, but also other implementations:
 
 - [Mastodon](https://joinmastodon.org/) (microblogging)
 - [PeerTube](https://joinpeertube.org/) (videos)

--- a/src/en/introduction.md
+++ b/src/en/introduction.md
@@ -8,7 +8,7 @@ A Lemmy website can operate alone. Just like a traditional website, people sign 
 
 Lemmy uses a standardized, open protocol to implement federation which is called ActivityPub. Any software that likewise implements federation via ActivityPub can seamlessly communicate with Lemmy, just like Lemmy instances communicate with one another.
 
-The fediverse ("federated universe") is teh name for all instances that can communicate with each other over ActivityPub and the World Wide Web. That includes all Lemmy servers, but also other implementations:
+The fediverse ("federated universe") is the name for all instances that can communicate with each other over ActivityPub and the World Wide Web. That includes all Lemmy servers, but also other implementations:
 
 - [Mastodon](https://joinmastodon.org/) (microblogging)
 - [PeerTube](https://joinpeertube.org/) (videos)


### PR DESCRIPTION
Per https://github.com/LemmyNet/lemmy-docs/pull/191#issuecomment-1582497270

Using: https://github.com/crate-ci/typos

You can see this works by looking at [this](https://woodpecker.join-lemmy.org/LemmyNet/lemmy-docs/pipeline/89/1) run where there is an intentional typo.

I wanted to install the latest version of typos but there is a weird problem that even when I set the docker image to the latest version of rust it was still using an old version that didn't work for typos.

@Nutomic recommended using a prebuilt binary for now so that's what I did.

An alternative would be to use https://hub.docker.com/r/imunew/typos-cli but who knows if it will be maintained. 

Open to suggestions for improving this.