### PR TITLE
add github repository url to config

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -2,6 +2,9 @@
 authors = ["Felix Ableitner"]
 src = "src"
 
+[output.html]
+git-repository-url = "https://github.com/LemmyNet/lemmy-docs"
+
 [language.en]
 name = "English"
 title = "Lemmy Documentation"


### PR DESCRIPTION
Adds this little button to link to the github repo.

I originally wanted to add the edit button via `edit-url-template` mentioned [here](https://rust-lang.github.io/mdBook/format/configuration/renderers.html) but I don't think it can work with multiple languages. 

<img width="1509" alt="image" src="https://github.com/LemmyNet/lemmy-docs/assets/921217/0d77c81d-bb12-4c80-a052-875e0603cf4d">
