### PR TITLE
Add new requirements for an instance being included on join-lemmy.org

### DIFF
--- a/src/en/administration/first_steps.md
+++ b/src/en/administration/first_steps.md
@@ -30,7 +30,13 @@ To be included in the list of Lemmy instances on [join-lemmy.org](https://join-l
 
 - [x] Federate with at least one instance from the list
 - [x] Have a site description and icon
+- [x] Don't have closed sign-ups
+- [x] Have at least 5 users who posted or commented at least once in the past month
+- [x] Be on the latest major version of Lemmy
 - [x] Be patient and wait the site to be updated, there's no fixed schedule for that
+
+Recommended instances are defined in code [here](https://github.com/LemmyNet/joinlemmy-site/blob/main/recommended-instances.json)
+and the code that powers the crawler is visible [here](https://github.com/LemmyNet/lemmy-stats-crawler).
 
 In the meantime you can always promote your server on other social networks like Mastodon using the hashtag `#Lemmy`.
 


### PR DESCRIPTION
In https://github.com/LemmyNet/joinlemmy-site/commit/acd202c5909fe85e6c4c31ce2510c3635d99ee0c, the requirements for an instance being visible on join-lemmy.org changed. This PR updates the docs to reflect the new requirements.