### PR TITLE
Link to docker-compose.yml and lemmy.hjson on main

### DIFF
--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -8,8 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # download default config files
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.17/docker/prod/docker-compose.yml
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/release/v0.17/docker/prod/lemmy.hjson
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
 
 # Set correct permissions for pictrs folder
 mkdir -p volumes/pictrs

--- a/src/es/administration/install_docker.md
+++ b/src/es/administration/install_docker.md
@@ -8,9 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # descarga los archivos de la configuración por defecto
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/docker-compose.yml
 wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/iframely.config.local.js
 
 # Establece los permisos correctos para la carpeta pictrs
 mkdir -p volumes/pictrs

--- a/src/fr/administration/install_docker.md
+++ b/src/fr/administration/install_docker.md
@@ -8,9 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # télécharger les fichiers de configuration par défaut
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/docker-compose.yml
 wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/iframely.config.local.js
 
 # Définir les permissions correctes pour le dossier pictrs
 mkdir -p volumes/pictrs

--- a/src/id/administration/install_docker.md
+++ b/src/id/administration/install_docker.md
@@ -8,7 +8,7 @@ mkdir /lemmy
 cd /lemmy
 
 # unduh berkas konfigurasi baku
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/docker-compose.yml
 wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
 
 # atur izin yang benar untuk folder pictrs

--- a/src/ru/administration/install_docker.md
+++ b/src/ru/administration/install_docker.md
@@ -8,9 +8,8 @@ mkdir /lemmy
 cd /lemmy
 
 # загрузите кнфигурацию по умолчанию
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/prod/docker-compose.yml
+wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/docker-compose.yml
 wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/lemmy.hjson
-wget https://raw.githubusercontent.com/LemmyNet/lemmy/main/docker/iframely.config.local.js
 
 # Установите корректные разрешения для каталога pictrs
 mkdir -p volumes/pictrs


### PR DESCRIPTION
People on Matrix are still having trouble with docker setups due to issues that are already fixed on `main`. Seems like for now at least we should link directly to `main` and maybe revisit this for 0.18.