### PR TITLE
Fix http_accept header in nginx.conf for docker install

### DIFF
--- a/src/en/administration/install_docker.md
+++ b/src/en/administration/install_docker.md
@@ -59,10 +59,7 @@ http {
             # don't change lemmy-ui or lemmy here, they refer to the upstream definitions on top
             set $proxpass "http://lemmy-ui";
 
-            if ($http_accept = "application/activity+json") {
-              set $proxpass "http://lemmy";
-            }
-            if ($http_accept = "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"") {
+            if ($http_accept ~ "^application/.*$") {
               set $proxpass "http://lemmy";
             }
             if ($request_method = POST) {


### PR DESCRIPTION
The current `nginx.conf` in the english docker install doc has a very strict `http_accept` header check. It prevents other services in the Fediverse like Mastodon and Kbin federating with the Lemmy instance due to the way they send the `http_accept` header.

The change updates the `http_accept` header check and aligns it with the one in the [ansible template](https://github.com/LemmyNet/lemmy-ansible/blob/fa12b2e0705a70ebaa2dde19043ee9ae38e4c74c/templates/nginx.conf#L63).