### PR TITLE
Update 02-local-development.md

### DIFF
--- a/src/en/contributors/02-local-development.md
+++ b/src/en/contributors/02-local-development.md
@@ -44,6 +44,11 @@ Arch-based distro:
 ```bash
 sudo pacman -S postgresql
 sudo systemctl start postgresql
+# If the systemctl command errors, then run the following
+sudo mkdir /var/lib/postgres/data
+sudo chown postgres:postgres /var/lib/postgres/data
+sudo -u postgres initdb -D /var/lib/postgres/data
+sudo systemctl start postgresql
 ```
 
 macOS:


### PR DESCRIPTION
I have added some debugging notes that might save some time for an Arch user setting up Postgres. Specifically, sometimes pacman sets up the database cluster incorrectly and some extra bash commands need to be issued before systemctl can start the service.