### PR TITLE
Correct package names for Arch local development

### DIFF
--- a/src/en/contributors/02-local-development.md
+++ b/src/en/contributors/02-local-development.md
@@ -17,9 +17,7 @@ sudo apt update && sudo apt install yarn
 Arch-based distro:
 
 ```bash
-sudo pacman -S git cargo libssl-dev pkg-config libpq-dev curl
-# install yarn (stable)
-curl -o- -L https://yarnpkg.com/install.sh | bash
+sudo pacman -S git cargo openssl pkg-config postgresql-libs curl yarn
 ```
 
 macOS:


### PR DESCRIPTION
Fixes the package names on Arch Linux.

```shell
ldd ./target/debug/lemmy_server                                                                                                                                                                                                        
        libssl.so.3 => /usr/lib/libssl.so.3 (0x00007f4435d60000)
        libpq.so.5 => /usr/lib/libpq.so.5 (0x00007f4435d0d000)
```
Checking which packages own the relevant files:

```shell
pacman -Qo /usr/lib/libssl.so.3
/usr/lib/libssl.so.3 is owned by openssl 3.1.1-1

pacman -Qo /usr/include/openssl/
/usr/include/openssl/ is owned by openssl 3.1.1-1
```

```shell
pacman -Qo /usr/lib/libpq.so.5
/usr/lib/libpq.so.5 is owned by postgresql-libs 15.3-1

pacman -Qo /usr/include/postgresql/
/usr/include/postgresql/ is owned by postgresql-libs 15.3-1
```

The latest `yarn` stable release is available in the Arch repos.