### PR TITLE
Update 02-local-development.md

### DIFF
--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -82,7 +82,7 @@ After making changes, you need to format the code with `cargo +nightly fmt --all
 
 ### Frontend development
 
-Install dependencies by running `yarn`. Then run `yarn build:dev --watch` to launch lemmy-ui locally. It automatically connects to the Lemmy backend on `localhost:8536`. Open [localhost:1234](http://localhost:1234) in your browser. The project is rebuilt automatically when you change any files.
+Install dependencies by running `yarn`. Then run `yarn dev` to launch lemmy-ui locally. It automatically connects to the Lemmy backend on `localhost:8536`. Open [localhost:1234](http://localhost:1234) in your browser. The project is rebuilt automatically when you change any files.
 
 Note that this setup doesn't support image uploads. If you want to test those, you need to use the
 [Docker development](03-docker-development.md).

--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -82,7 +82,7 @@ After making changes, you need to format the code with `cargo +nightly fmt --all
 
 ### Frontend development
 
-Install dependencies by running `yarn`. Then run `yarn start` to launch lemmy-ui locally. It automatically connects to the Lemmy backend on `localhost:8536`. Open [localhost:1234](http://localhost:1234) in your browser. The project is rebuilt automatically when you change any files.
+Install dependencies by running `yarn`. Then run `yarn build:dev --watch` to launch lemmy-ui locally. It automatically connects to the Lemmy backend on `localhost:8536`. Open [localhost:1234](http://localhost:1234) in your browser. The project is rebuilt automatically when you change any files.
 
 Note that this setup doesn't support image uploads. If you want to test those, you need to use the
 [Docker development](03-docker-development.md).


### PR DESCRIPTION
When pull request #1517 was merged to lemmy-ui, which I have a link to [here](https://github.com/LemmyNet/lemmy-ui/commit/d0dff77377a84611ab5cf624123e84c95aedf1ff), the dev command to run the local frontend was changed from `yarn start` to `yarn build:dev --watch`. This updates the documents to reflect that.