### PR TITLE
Replace brew prefix with dynamic lookup

### DIFF
--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -54,7 +54,7 @@ macOS:
 ```bash
 brew install postgresql
 brew services start postgresql
-/usr/local/opt/postgres/bin/createuser -s postgres
+$(brew --prefix postgresql)/bin/createuser -s postgres
 ```
 
 Either execute `scripts/db-init.sh`, or manually initialize the postgres database:


### PR DESCRIPTION
Homebrew changed their default installation location, so using `/usr/local` might not work out-of-the-box for everyone, and will not work for more and more people going forward.