### PR TITLE
Update administration.md - Add Cosmos as installation methods

### DIFF
--- a/src/administration/administration.md
+++ b/src/administration/administration.md
@@ -26,6 +26,7 @@ In some cases, it might be necessary to use different installation methods.
 - [From Scratch](from_scratch.md)
 - [YunoHost](https://install-app.yunohost.org/?app=lemmy) ([source code](https://github.com/YunoHost-Apps/lemmy_ynh))
 - [On Amazon Web Services (AWS)](on_aws.md)
+- [Cosmos](https://cosmos-cloud.io/proxy#cosmos-ui/market-listing/cosmos-cloud/Lemmy) ([source code](https://github.com/azukaar/cosmos-servapps-official/blob/master/servapps/Lemmy/cosmos-compose.json))
 
 ### You could use any other reverse proxy
 


### PR DESCRIPTION
I added Cosmos as an install method, it is similar to Yunohost, proposes one click docker installation from the official docker image. The link itself redirects to a similar page than say Homeassistant or Yunohost would do:

![image](https://github.com/LemmyNet/lemmy-docs/assets/7872597/f18eddd0-747d-4b27-a8de-4f1527460ae3)
