### PR TITLE
From scratch updates2023 06 30

### DIFF
--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -46,7 +46,7 @@ Compile and install Lemmy, given the from-scratch intention, this will be done v
 apt install protobuf-compiler
 git clone https://github.com/LemmyNet/lemmy.git lemmy
 cd lemmy
-git checkout 0.18.0
+git checkout 0.18.2
 git submodule init
 git submodule update --recursive --remote
 echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"
@@ -129,7 +129,7 @@ curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt install nodejs yarn
 ```
 
-Clone the git repo, checkout the version you want (0.18.0 in this case), and compile it.
+Clone the git repo, checkout the version you want (0.18.2 in this case), and compile it.
 
 ```bash
 mkdir /var/lib/lemmy-ui
@@ -138,7 +138,7 @@ chown lemmy:lemmy .
 # dont compile as admin
 sudo -u lemmy bash
 git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .
-git checkout 0.18.0 # replace with the version you want to install
+git checkout 0.18.2 # replace with the version you want to install
 yarn install --pure-lockfile
 yarn build:prod
 exit
@@ -220,10 +220,10 @@ systemctl restart lemmy
 
 ```bash
 cd /var/lib/lemmy-ui
-sudo -u lemmy
+sudo -u lemmy bash
 git checkout main
 git pull --tags
-git checkout 0.18.0 # replace with the version you want to install
+git checkout 0.18.2 # replace with the version you want to install
 git submodule update
 yarn install --pure-lockfile
 yarn build:prod

--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -215,11 +215,13 @@ Now open your Lemmy domain in the browser, and it should show you a configuratio
 
 ### Lemmy
 
-Compile and install Lemmy changes. This can be done by a normal unprivledged user (using the same Linux account you used for rustup and first install of Lemmy). 
+Compile and install lemmy_server changes. This compile can be done by a normal unprivledged user (using the same Linux account you used for rustup and first install of Lemmy). 
 
 ```bash
+rustup update
 cd lemmy
-git pull
+git checkout main
+git pull --tags
 git checkout 0.18.2 # replace with version you are updating to
 git submodule update --recursive --remote
 echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/version.rs"

--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -42,7 +42,7 @@ sudo adduser lemmy --system --disabled-login --no-create-home --group
 
 Tune your PostgreSQL settings to match your hardware via https://pgtune.leopard.in.ua/#/
 
-Compile and install Lemmy, given the from-scratch intention, this will be done via GitHub checkout. This can be done by a norm unprivledged user (using the same Linux account you used for rustup). 
+Compile and install Lemmy, given the from-scratch intention, this will be done via GitHub checkout. This can be done by a normal unprivledged user (using the same Linux account you used for rustup). 
 
 ```bash
 # protobuf-compiler may be required for Ubuntu 22.04.2 installs, please report testing in lemmy-docs issues
@@ -215,7 +215,7 @@ Now open your Lemmy domain in the browser, and it should show you a configuratio
 
 ### Lemmy
 
-Compile and install Lemmy changes. This can be done by a norm unprivledged user (using the same Linux account you used for rustup and first install of Lemmy). 
+Compile and install Lemmy changes. This can be done by a normal unprivledged user (using the same Linux account you used for rustup and first install of Lemmy). 
 
 ```bash
 cd lemmy
@@ -227,9 +227,11 @@ echo "pub const VERSION: &str = \"$(git describe --tag)\";" > "crates/utils/src/
 # OPTIONAL on next command: --features embed-pictrs
 cargo build --release
 # copy compiled binary to destination
-sudo cp target/release/lemmy_server /usr/bin/lemmy_server
+# the old file will be locked by the already running application, so this sequence is recommended:
+sudo -- sh -c 'systemctl stop lemmy && cp target/release/lemmy_server /usr/bin/lemmy_server && systemctl start lemmy'
 ```
 
+NOTE: 
 
 ### Lemmy UI
 

--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -42,7 +42,7 @@ sudo adduser lemmy --system --disabled-login --no-create-home --group
 
 Tune your PostgreSQL settings to match your hardware via https://pgtune.leopard.in.ua/#/
 
-Compile and install Lemmy, given the from-scratch intention, this will be done via GitHub checkout. This can be done by a normal unprivledged user (using the same Linux account you used for rustup). 
+Compile and install Lemmy, given the from-scratch intention, this will be done via GitHub checkout. This can be done by a normal unprivledged user (using the same Linux account you used for rustup).
 
 ```bash
 # protobuf-compiler may be required for Ubuntu 22.04.2 installs, please report testing in lemmy-docs issues
@@ -215,7 +215,7 @@ Now open your Lemmy domain in the browser, and it should show you a configuratio
 
 ### Lemmy
 
-Compile and install lemmy_server changes. This compile can be done by a normal unprivledged user (using the same Linux account you used for rustup and first install of Lemmy). 
+Compile and install lemmy_server changes. This compile can be done by a normal unprivledged user (using the same Linux account you used for rustup and first install of Lemmy).
 
 ```bash
 rustup update

--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -1,6 +1,6 @@
 # From Scratch
 
-These instructions are written for Ubuntu 20.04.
+These instructions are written for Ubuntu 20.04 / Ubuntu 22.04.
 
 ## Installation
 
@@ -85,6 +85,7 @@ Environment=LEMMY_CONFIG_LOCATION=/etc/lemmy/lemmy.hjson
 # remove these two lines if you don't need pict-rs
 Environment=PICTRS_PATH=/var/lib/pictrs
 Environment=PICTRS_ADDR=127.0.0.1:8080
+Environment=RUST_LOG=info
 Restart=on-failure
 
 # Hardening
@@ -101,7 +102,7 @@ If you did everything right, the Lemmy logs from `journalctl -u lemmy` should sh
 
 ### Install lemmy-ui (web frontend)
 
-Install dependencies (nodejs and yarn in Ubuntu 20.04 repos are too old)
+Install dependencies (nodejs and yarn in Ubuntu 20.04 / Ubuntu 22.04 repos are too old)
 
 ```bash
 # https://classic.yarnpkg.com/en/docs/install/#debian-stable
@@ -112,7 +113,7 @@ curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt install nodejs yarn
 ```
 
-Clone the git repo, checkout the version you want (0.16.7 in this case), and compile it.
+Clone the git repo, checkout the version you want (0.18.0 in this case), and compile it.
 
 ```bash
 mkdir /var/lib/lemmy-ui
@@ -121,7 +122,7 @@ chown lemmy:lemmy .
 # dont compile as admin
 sudo -u lemmy bash
 git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .
-git checkout 0.16.7 # replace with the version you want to install
+git checkout 0.18.0 # replace with the version you want to install
 yarn install --pure-lockfile
 yarn build:prod
 exit
@@ -142,7 +143,6 @@ ExecStart=/usr/bin/node dist/js/server.js
 Environment=LEMMY_UI_LEMMY_INTERNAL_HOST=localhost:8536
 Environment=LEMMY_UI_LEMMY_EXTERNAL_HOST=example.com
 Environment=LEMMY_UI_HTTPS=true
-Environment=RUST_LOG=info
 Restart=on-failure
 
 # Hardening
@@ -207,7 +207,7 @@ cd /var/lib/lemmy-ui
 sudo -u lemmy
 git checkout main
 git pull --tags
-git checkout 0.12.2 # replace with the version you want to install
+git checkout 0.18.0 # replace with the version you want to install
 git submodule update
 yarn install --pure-lockfile
 yarn build:prod

--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -231,8 +231,6 @@ cargo build --release
 sudo -- sh -c 'systemctl stop lemmy && cp target/release/lemmy_server /usr/bin/lemmy_server && systemctl start lemmy'
 ```
 
-NOTE: 
-
 ### Lemmy UI
 
 ```bash


### PR DESCRIPTION
Some of the notes scattered about on Lenny discussions and issues into from-scratch install. This still needs testing on a virgin Ubuntu 22.04 install to make sure it has all the libraries and no steps are missing.

Example checkouts are now 0.18.0 version of Lemmy. Ubuntu 22.04 is mentioned along with Ubuntu 20.04