### PR TITLE
local-development.md reference from-scratch for Debain/Ubuntu

### DIFF
--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -108,7 +108,7 @@ To run federation/API tests, first add the following lines to `/etc/hosts`:
 127.0.0.1       lemmy-epsilon
 ```
 
-Then run the following script:
+You will need to hand-edit the api_tests/run-federation-test.sh script file, add your PostgreSQL lemmy password. Note, the LEMMY_DATABASE_URL environment variable inside that script file is not in the same format as normally required, the "/lemmy" database is not on the URL. Then run the following script:
 
 ```bash
 cd api_tests

--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -14,8 +14,7 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 sudo apt update && sudo apt install yarn
 ```
 
-NOTE: you may find it is useful to reference the - [Install from Scratch](../administration/from_scratch.md)
- steps for Debian/Ubuntu, as production servers are assumed to be same.
+NOTE: you may find it is useful to reference the - [Install from Scratch](../administration/from_scratch.md) steps for Debian/Ubuntu, as production servers are assumed to be same.
 
 Arch-based distro:
 

--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -14,7 +14,8 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 sudo apt update && sudo apt install yarn
 ```
 
-NOTE: you may find it is useful to reference the - [Install from Scratch](../administration/from_scratch.md) steps for Debian/Ubuntu, as production servers are assumed to be same.
+NOTE: you may find it is useful to reference the - [Install from Scratch](../administration/from_scratch.md)
+steps for Debian/Ubuntu, as production servers are assumed to be same.
 
 Arch-based distro:
 

--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -14,6 +14,9 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 sudo apt update && sudo apt install yarn
 ```
 
+NOTE: you may find it is useful to reference the - [Install from Scratch](../administration/from_scratch.md)
+ steps for Debian/Ubuntu, as production servers are assumed to be same.
+
 Arch-based distro:
 
 ```bash


### PR DESCRIPTION
Typo: "front-scratch" was supposed to be "from-scratch".