### PR TITLE
Updated link to latest Ubuntu

### DIFF
--- a/src/administration/install_docker.md
+++ b/src/administration/install_docker.md
@@ -63,7 +63,7 @@ If you've set up Let's Encrypt and your reverse proxy, you can go to `https://{{
 
 ## Let's Encrypt
 
-You should also setup TLS, for example with [Let's Encrypt](https://letsencrypt.org/). [Here's a guide for setting up letsencrypt on Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-20-04).
+You should also setup TLS, for example with [Let's Encrypt](https://letsencrypt.org/). [Here's a guide for setting up letsencrypt on Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-22-04).
 
 For federation to work, it is important that you do not change any headers that form part of the signature. This includes the `Host` header - you may need to refer to the documentation for your proxy server to pass through the `Host` header unmodified.
 


### PR DESCRIPTION
This commit updates the TLS guide from Ubuntu 20.04 to 22.04 (latest LTS).