### PR TITLE
Fix libraries link in API documentation

### DIFF
--- a/src/contributors/04-api.md
+++ b/src/contributors/04-api.md
@@ -1,6 +1,6 @@
 ## API
 
-Lemmy has an HTTP API for clients and frontends. See the [API documentation](/api) for more information. Instead of using the API directly you can use one of the existing [libraries](https://github.com/LemmyNet/lemmy#libraries). You can either interact with a local development instance via `http://localhost:8536`, or connect to a production instance. The following instances are available for testing purposes:
+Lemmy has an HTTP API for clients and frontends. See the [API documentation](/api) for more information. Instead of using the API directly you can use one of the existing [libraries](https://github.com/dbeley/awesome-lemmy#libraries). You can either interact with a local development instance via `http://localhost:8536`, or connect to a production instance. The following instances are available for testing purposes:
 
 - https://enterprise.lemmy.ml/
 - https://ds9.lemmy.ml/


### PR DESCRIPTION
The content in the README was apparently moved in https://github.com/LemmyNet/lemmy/commit/050216eed97380c8c1682ba065cf5e62f0961934