### PR TITLE
Restore update-includes.sh script in CI

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -28,6 +28,7 @@ pipeline:
   check_documentation_build:
     image: alpine:3
     commands:
+      - apk add bash curl git
       - wget -O mdbook.tar.gz https://github.com/rust-lang/mdBook/releases/download/v0.4.30/mdbook-v0.4.30-x86_64-unknown-linux-musl.tar.gz
       - tar -xzf mdbook.tar.gz
       - ls -la mdbook

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -31,6 +31,7 @@ pipeline:
       - wget -O mdbook.tar.gz https://github.com/rust-lang/mdBook/releases/download/v0.4.30/mdbook-v0.4.30-x86_64-unknown-linux-musl.tar.gz
       - tar -xzf mdbook.tar.gz
       - ls -la mdbook
+      - ./update-includes.sh
       - ./mdbook build .
 
   dead_links:


### PR DESCRIPTION
It was removed in 0dc13b4ea11daaa07d964c17f7a622e3a222367a and since then the CI build throws a bunch of errors but still exits with status code 0.

There's an [open issue in mdBook](https://github.com/rust-lang/mdBook/issues/1094) regarding the behavior of broken links and the exit code but it looks stale. 