### PR TITLE
Add `proxy_params` to list of files to download for docker-compose

### DIFF
--- a/src/administration/install_docker.md
+++ b/src/administration/install_docker.md
@@ -20,6 +20,7 @@ The images will likely be: [dessalines/lemmy:VERSION](https://hub.docker.com/r/d
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-ansible/main/templates/docker-compose.yml
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-ansible/main/examples/config.hjson -O lemmy.hjson
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-ansible/main/templates/nginx_internal.conf
+wget https://raw.githubusercontent.com/LemmyNet/lemmy-ansible/main/files/proxy_params
 ```
 
 If you'd like further customization, have a look at the [config file](configuration.md) named `lemmy.hjson`, and adjust it accordingly.


### PR DESCRIPTION
In https://github.com/LemmyNet/lemmy-ansible/pull/161 the `proxy_params` file was introduced. This file needs to be downloaded so it gets mounted in the `nginx` container.

https://github.com/LemmyNet/lemmy-ansible/pull/161/files#diff-a78c3c6b9adf66d21f26347f9c0cdb09ed9813c8cd95e56bea726bc86068c294