### PR TITLE
Remove references to legacy Docker Compose v1

### DIFF
--- a/src/administration/backup_and_restore.md
+++ b/src/administration/backup_and_restore.md
@@ -9,7 +9,7 @@ When using docker or ansible, there should be a `volumes` folder, which contains
 To take a complete backup of the DB to a `.sql.gz` file, you can run:
 
 ```bash
-docker-compose exec postgres pg_dumpall -c -U lemmy | gzip > lemmy_dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql.gz
+docker compose exec postgres pg_dumpall -c -U lemmy | gzip > lemmy_dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql.gz
 ```
 
 _For compression, you can use either gzip and gunzip, or xz and unxz._
@@ -19,7 +19,7 @@ _For compression, you can use either gzip and gunzip, or xz and unxz._
 ```bash
 #!/bin/sh
 # DB Backup
-ssh MY_USER@MY_IP "docker-compose exec postgres pg_dumpall -c -U lemmy" | gzip > ~/BACKUP_LOCATION/INSTANCE_NAME_dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql.gz
+ssh MY_USER@MY_IP "docker compose exec postgres pg_dumpall -c -U lemmy" | gzip > ~/BACKUP_LOCATION/INSTANCE_NAME_dump_`date +%Y-%m-%d"_"%H_%M_%S`.sql.gz
 
 # Volumes folder Backup
 rsync -avP -zz --rsync-path="sudo rsync" MY_USER@MY_IP:/LEMMY_LOCATION/volumes ~/BACKUP_LOCATION/FOLDERNAME
@@ -30,17 +30,17 @@ rsync -avP -zz --rsync-path="sudo rsync" MY_USER@MY_IP:/LEMMY_LOCATION/volumes ~
 To restore, run:
 
 ```bash
-docker-compose up -d postgres
+docker compose up -d postgres
 
 # Restore from the .sql.gz backup
-gunzip < db_dump.sql  |  docker-compose exec -T postgres psql -U lemmy
+gunzip < db_dump.sql  |  docker compose exec -T postgres psql -U lemmy
 
 # Note: You may need to change the permissions on the postgres directory, depending on your system.
 chown -R $USER volumes
-docker-compose restart postgres
+docker compose restart postgres
 
 # Continue with the startup
-docker-compose up -d
+docker compose up -d
 ```
 
 If you've accidentally already started the lemmy service, you need to clear out your existing database:
@@ -61,7 +61,7 @@ If you haven't federated yet, you can change your domain name in the DB. **Warni
 
 Get into `psql` for your docker:
 
-`docker-compose exec postgres psql -U lemmy`
+`docker compose exec postgres psql -U lemmy`
 
 ```sql
 -- Instance

--- a/src/administration/install_docker.md
+++ b/src/administration/install_docker.md
@@ -1,6 +1,6 @@
 # Docker Installation
 
-Make sure you have both docker and docker-compose(>=`1.24.0`) installed. On Ubuntu, just run `apt install docker-compose docker.io`. Next,
+Make sure you have both docker and docker-compose(>=`2.0`) installed. On Ubuntu, just run `apt install docker-compose-v2 docker.io`. Next,
 
 ```bash
 # Create a folder for the lemmy files. the location doesnt matter, you can put this anywhere you want
@@ -46,7 +46,7 @@ sudo chown -R 991:991 volumes/pictrs
 
 Finally, run:
 
-`docker-compose up -d`
+`docker compose up -d`
 
 lemmy-ui is accessible on the server at `http://localhost:{{ lemmy_port }}`
 
@@ -77,5 +77,5 @@ To update to the newest version, you can manually change the version in `docker-
 ```bash
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-ansible/main/templates/docker-compose.yml
 # Then replace the {{ }} vars again
-docker-compose up -d
+docker compose up -d
 ```

--- a/src/administration/install_docker.md
+++ b/src/administration/install_docker.md
@@ -1,6 +1,6 @@
 # Docker Installation
 
-Make sure you have both docker and docker-compose(>=`2.0`) installed. On Ubuntu, just run `apt install docker-compose-v2 docker.io`. Next,
+Make sure you have both docker and docker-compose(>=`2.0`) installed. On Ubuntu, just run `apt install docker-compose-v2 docker.io`. On Debian, you need to install Docker [using their official installation instructions and custom `apt` repo](https://docs.docker.com/engine/install/debian/). Next,
 
 ```bash
 # Create a folder for the lemmy files. the location doesnt matter, you can put this anywhere you want

--- a/src/administration/troubleshooting.md
+++ b/src/administration/troubleshooting.md
@@ -10,9 +10,9 @@ Many Lemmy features depend on a correct reverse proxy configuration. Make sure y
 
 For frontend issues, check the [browser console](https://webmasters.stackexchange.com/a/77337) for any error messages.
 
-For server logs, run `docker-compose logs -f lemmy` in your installation folder. You can also do `docker-compose logs -f lemmy lemmy-ui pictrs` to get logs from different services.
+For server logs, run `docker compose logs -f lemmy` in your installation folder. You can also do `docker compose logs -f lemmy lemmy-ui pictrs` to get logs from different services.
 
-If that doesn't give enough info, try changing the line `RUST_LOG=error` in `docker-compose.yml` to `RUST_LOG=info` or `RUST_LOG=verbose`, then do `docker-compose restart lemmy`.
+If that doesn't give enough info, try changing the line `RUST_LOG=error` in `docker-compose.yml` to `RUST_LOG=info` or `RUST_LOG=verbose`, then do `docker compose restart lemmy`.
 
 ### Creating admin user doesn't work
 


### PR DESCRIPTION
Docker Compose v2 was released in 2020. v1 was deprecated in 2022 and no longer receives any updates as of July 2023. v2 uses `docker compose` rather than `docker-compose`.