### PR TITLE
Update link to current API version

### DIFF
--- a/src/contributors/04-api.md
+++ b/src/contributors/04-api.md
@@ -15,7 +15,7 @@ More clearly arranged, unofficial API documentation is available at:
 
 **GET example**
 
-The current api `{version}` is [here](https://github.com/LemmyNet/lemmy-js-client/blob/main/src/types/others.ts#L1).
+The current API `{version}` is [here](https://github.com/LemmyNet/lemmy-js-client/blob/main/src/other_types.ts#L1).
 
 ```
 curl "https://lemmy.ml/api/{version}/community/list?sort=Hot"`


### PR DESCRIPTION
On the [API page](https://join-lemmy.org/docs/contributors/04-api.html), the link to the current API version currently points to a file that no longer exists: \
https://github.com/LemmyNet/lemmy-js-client/blob/main/src/types/others.ts#L1

This pull request updates the link to point to the correct file: \
https://github.com/LemmyNet/lemmy-js-client/blob/main/src/other_types.ts#L1