### PR TITLE
Add gcc to from_scratch.md instructions

### DIFF
--- a/src/administration/from_scratch.md
+++ b/src/administration/from_scratch.md
@@ -55,7 +55,7 @@ For the Rust compiles, it is ideal to use a non-privileged Linux account on your
 protobuf-compiler may be required for Ubuntu 20.04 or 22.04 installs, please report testing in lemmy-docs issues.
 
 ```
-sudo apt install protobuf-compiler
+sudo apt install protobuf-compiler gcc
 ```
 
 ### Setup pict-rs (Optional)


### PR DESCRIPTION
We need to have `cc` command for this step:

```
cargo build --release --features embed-pictrs
```

So installing `gcc` early on will help with that.