### PR TITLE
Update RUST_LOG from verbose to debug, as verbose outputs no logging

### DIFF
--- a/src/administration/troubleshooting.md
+++ b/src/administration/troubleshooting.md
@@ -12,7 +12,7 @@ For frontend issues, check the [browser console](https://webmasters.stackexchang
 
 For server logs, run `docker compose logs -f lemmy` in your installation folder. You can also do `docker compose logs -f lemmy lemmy-ui pictrs` to get logs from different services.
 
-If that doesn't give enough info, try changing the line `RUST_LOG=error` in `docker-compose.yml` to `RUST_LOG=info` or `RUST_LOG=verbose`, then do `docker compose restart lemmy`.
+If that doesn't give enough info, try changing the line `RUST_LOG=error` in `docker-compose.yml` to `RUST_LOG=info` or `RUST_LOG=debug`, then do `docker compose restart lemmy`.
 
 ### Creating admin user doesn't work
 

--- a/src/administration/troubleshooting.md
+++ b/src/administration/troubleshooting.md
@@ -12,7 +12,7 @@ For frontend issues, check the [browser console](https://webmasters.stackexchang
 
 For server logs, run `docker compose logs -f lemmy` in your installation folder. You can also do `docker compose logs -f lemmy lemmy-ui pictrs` to get logs from different services.
 
-If that doesn't give enough info, try changing the line `RUST_LOG=error` in `docker-compose.yml` to `RUST_LOG=info` or `RUST_LOG=debug`, then do `docker compose restart lemmy`.
+If that doesn't give enough info, try changing the line `RUST_LOG=error` in `docker-compose.yml` to `RUST_LOG=info` or `RUST_LOG=trace`, then do `docker compose restart lemmy`.
 
 ### Creating admin user doesn't work
 


### PR DESCRIPTION
When troubleshooting, `verbose` value for `RUST_LOG` doesn't print anything, not even `info` values. So if you're trying to figure out why your upgrade isn't loading in the UI, you turn on verbose logging but can't see that the DB migrations are running.

Updated the "most verbose" line in the Troubleshooting doc to use `debug` instead, which provides more context than `info`.