### PR TITLE
Remove unofficial API docs.

### DIFF
--- a/src/contributors/04-api.md
+++ b/src/contributors/04-api.md
@@ -13,11 +13,6 @@ Instead of using the API directly you can use one of the existing [libraries](ht
 - https://ds9.lemmy.ml/
 - https://voyager.lemmy.ml/
 
-Other unofficial API documentation is available at:
-
-- [lemmy.readme.io](https://lemmy.readme.io/)
-- [mv-gh.github.io/lemmy_openapi_spec](https://mv-gh.github.io/lemmy_openapi_spec/)
-
 ### Curl Examples
 
 **GET example**


### PR DESCRIPTION
- These aren't maintained anymore anyway, and future releases will have OpenAPI docs along with them.