### PR TITLE
Replaced references of Bootstrap version v4 with v5 in the Theming Guide

### DIFF
--- a/src/administration/theming.md
+++ b/src/administration/theming.md
@@ -1,6 +1,6 @@
 # Theming Guide
 
-Lemmy uses [Bootstrap v4](https://getbootstrap.com/), and very few custom css classes, so any bootstrap v4 compatible theme should work fine. Use a tool like [bootstrap.build](https://bootstrap.build/) to create a bootstrap v4 theme. Export the `bootstrap.min.css` once you're done, and save the `_variables.scss` too.
+Lemmy uses [Bootstrap v5](https://getbootstrap.com/), and very few custom css classes, so any bootstrap v5 compatible theme should work fine. Use a tool like [bootstrap.build](https://bootstrap.build/) to create a bootstrap v5 theme. Export the `bootstrap.min.css` once you're done, and save the `_variables.scss` too.
 
 If you installed Lemmy with Docker, save your theme file to `./volumes/lemmy-ui/extra_themes`. For native installation (without Docker), themes are loaded by lemmy-ui from ./extra_themes folder. A different path can be specified with LEMMY_UI_EXTRA_THEMES_FOLDER environment variable.
 


### PR DESCRIPTION
Reference to issue #251. Updated the Bootstrap version number (v4) to the latest version (v5).