### PR TITLE
I've updated the Theming Guide with information about creating themes

### DIFF
--- a/src/administration/theming.md
+++ b/src/administration/theming.md
@@ -1,7 +1,96 @@
 # Theming Guide
 
+## Bootstrap
+
 Lemmy uses [Bootstrap v5](https://getbootstrap.com/), and very few custom css classes, so any bootstrap v5 compatible theme should work fine. Use a tool like [bootstrap.build](https://bootstrap.build/) to create a bootstrap v5 theme. Export the `bootstrap.min.css` once you're done, and save the `_variables.scss` too.
+
+## Custom Theme Directory
 
 If you installed Lemmy with Docker, save your theme file to `./volumes/lemmy-ui/extra_themes`. For native installation (without Docker), themes are loaded by lemmy-ui from ./extra_themes folder. A different path can be specified with LEMMY_UI_EXTRA_THEMES_FOLDER environment variable.
 
 After a theme is added, users can select it under `/settings`. Admins can set a theme as site default under `/admin`.
+
+## Default Theme Locations
+
+Default Lemmy themes are located in `/lemmy-ui/src/assets/css/themes`. Atom themes used for styling `<code>` are in `/lemmy-ui/src/assets/css/code-themes`.
+
+## Making CSS themes with Sass and Bootstrap
+
+Some tips if making a theme based off the default Lemmy themes (recommended approach). 
+
+Every theme has these files: 
+
+- an output `theme.css`
+- an output `theme.css.map`
+- `theme.scss`
+- `_variables.theme.scss`
+
+All `_variables.theme.scss` files will inherit variables from `_variables.scss`.
+All `theme.scss` will import bootstrap variables from `"../../../../node_modules/bootstrap/scss/bootstrap";` and its `_variables.theme.scss` file. It may import additional variables from another theme if it is built off it. For example, `litely-compact.scss` imports from `_variables.litely.scss`.
+
+### Using SCSS Files
+
+If you are new to Sass, keep in mind that `theme.scss` files are for css and Sass flavored css. `_variables.theme.scss` are for variables. 
+
+### Export Your CSS File 
+
+To export your custom `.scss` and `_variables.theme.scss` files to a `.css` file open the command line in the same directory as your files and run:
+`sass theme.scss theme.css` which will generate the `.css` and `.css.map` files.
+
+### Bootstrap Notes
+
+If you are new to Bootstrap, be aware that variables starting with a dollar sign like `$variable` are Bootstrap variables and when output to css will look like `--bs-variable`. You can also define custom root variables in your `_variables.theme.scss` files like `:root {--custom-variable: value;};` and you can refer to this again in your `theme.scss` file.
+
+#### Bootstrap Variables on Lemmy
+
+For the `darkly.css` theme, the bootstrap colours are used in the following contexts (not an exhaustive list):
+
+##### Grayscales
+
+- `bs-white` is used for `bs-emphasis`, `bs-table`, `border-white`, `text-light`
+- `bs-gray-300` is used for `bs-dark`, `bs-dark-emphasis`, and others
+- `bs-gray-500` is used for `bs-button-bg`, other button styles, `bs-button-disabled`, and some other inputs
+- `bs-gray-600` is used for the blockquote footer, disabled forms, disabled buttons, the dropdown heading colour, and `bs-gray`
+- `bs-700` is used for the card header background
+- `bs-800` is used for the card background and `bs-light`
+- `bs-gray-900` is the background colour
+
+##### Colours
+
+- `bs-red` is used as `bs-danger`
+- `bs-yellow` is used as `bs-warning`
+- `bs-cyan` is used for `bs-info` which is the link colour
+
+##### Light and Dark Modes
+
+Even though `darkly.css` is a dark theme, it has in-built light and dark modes using media queries. The Bootstrap variables `$enable-dark-mode` and `$enable-light-mode` can be used to toggle this behaviour on or off.
+
+##### Grid Breakpoints
+
+You can change the grid breakpoints with the `$grid-breakpoints` variable. This might be important if you change the root font size or dramatically alter the layout.
+
+##### Everything else
+
+Most Lemmy theming is done with Bootstrap's default variables. Some variables are defined with `!important` which means if you have defined them in your custom theme that unless it also has `!important` it will be overwritten. To check, do a search in one of the default theme files or use the Developer Tools in your browser.
+
+To quickly test your theme if you do not own a Lemmy instance, you can use a browser add on to load your custom CSS file.
+
+## How CSS themes are added to Settings
+
+In short, given the css theme is the correct file format and in the correct theme directory, it will be appended to the bottom of the theme list in Settings. The name is the filename minus the file extension. Details are below.
+
+### CSS Format Check
+
+The Typescript file `theme-handler.ts` in `/lemmy-ui/src/server/handlers/` will check for existing `css` files from the custom theme folder (`./volumes/lemmy-ui/extra_themes` or `./extra_themes`). Non `css` files will trigger an error.
+
+### Building the Theme List
+
+If a custom css theme is found, the handler will call `Themes-list-handler.ts` which will load `build-themes-list.ts` from `/lemmy-ui/src/server/utils/`. The file `buid-themes-list.ts` will search the directories for files ending in `.css` and build a list. 
+
+Custom themes are appended to the bottom of the theme list. 
+
+### Theme Names
+
+`build-themes-list.ts` will remove the file extension `.css` from the theme filename to display in Settings. For example, `darkly-compact.css` will appear as `darkly-compact`.
+
+

--- a/src/administration/theming.md
+++ b/src/administration/theming.md
@@ -1,6 +1,6 @@
 # Theming Guide
 
-Lemmy uses [Bootstrap v4](https://getbootstrap.com/), and very few custom css classes, so any bootstrap v4 compatible theme should work fine. Use a tool like [bootstrap.build](https://bootstrap.build/) to create a bootstrap v4 theme. Export the `bootstrap.min.css` once you're done, and save the `_variables.scss` too.
+Lemmy uses [Bootstrap v5](https://getbootstrap.com/), and very few custom css classes, so any bootstrap v5 compatible theme should work fine. Use a tool like [bootstrap.build](https://bootstrap.build/) to create a bootstrap v5 theme. Export the `bootstrap.min.css` once you're done, and save the `_variables.scss` too.
 
 If you installed Lemmy with Docker, save your theme file to `./volumes/lemmy-ui/extra_themes`. For native installation (without Docker), themes are loaded by lemmy-ui from ./extra_themes folder. A different path can be specified with LEMMY_UI_EXTRA_THEMES_FOLDER environment variable.
 


### PR DESCRIPTION
Updates are stacked with the other PR ([Replaced references of Bootstrap version v4 with v5 in the Theming Guide #351](https://github.com/LemmyNet/lemmy-docs/pull/351).

I updated the Theming Guide with some information about:

- dealing with Sass files
- how Bootstrap variables are used
- example Bootstrap variables and how they are used on Lemmy
- how the theme handlers load themes to the Settings menu

After making a Lemmy Theme myself and being unfamiliar with Bootstrap and Sass at the beginning, I remember thinking it would be helpful if this information was in the Theming Guide in case other theme developers are not familiar with the framework and how it is implemented.