### PR TITLE
Add documentation for running Lemmy on separate subdomains

### DIFF
--- a/assets/separate_subdomains/nginx/nginx_internal.conf
+++ b/assets/separate_subdomains/nginx/nginx_internal.conf
@@ -1,0 +1,99 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Docker internal DNS IP so we always get the newer containers without having to
+    # restart/reload the docker container / nginx configuration
+    resolver {{ nginx_internal_resolver }} valid=5s;
+
+    # set the real_ip when from docker internal ranges. Ensuring our internal nginx
+    # container can always see the correct ips in the logs
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+
+    # We construct a string consistent of the "request method" and "http accept header"
+    # and then apply soem ~simply regexp matches to that combination to decide on the
+    # HTTP upstream we should proxy the request to.
+    #
+    # Example strings:
+    #
+    #   "GET:application/activity+json"
+    #   "GET:text/html"
+    #   "POST:application/activity+json"
+    #
+    # You can see some basic match tests in this regex101 matching this configuration
+    # https://regex101.com/r/vwMJNc/1
+    #
+    # Learn more about nginx maps here http://nginx.org/en/docs/http/ngx_http_map_module.html
+    map "$request_method:$http_accept" $proxpass {
+        # If no explicit matches exists below, send traffic to Alexandrite
+        default "http://alexandrite:3000";
+
+        # GET/HEAD requests that accepts ActivityPub or Linked Data JSON should go to lemmy.
+        #
+        # These requests are used by Mastodon and other fediverse instances to look up profile information,
+        # discover site information and so on.
+        "~^(?:GET|HEAD):.*?application\/(?:activity|ld)\+json" "http://lemmy:8536";
+
+        # All non-GET/HEAD requests should go to lemmy
+        #
+        # Rather than calling out POST, PUT, DELETE, PATCH, CONNECT and all the verbs manually
+        # we simply negate the GET|HEAD pattern from above and accept all possibly $http_accept values
+        "~^(?!(GET|HEAD)).*:" "http://lemmy:8536";
+    }
+
+    server {
+        set $lemmy "lemmy:8536";
+        # this is the port inside docker, not the public one yet
+        listen 8536;
+
+        ## CHANGE `short.domain` HERE
+        server_name short.domain;
+        server_tokens off;
+
+        # Upload limit, relevant for pictrs
+        client_max_body_size 20M;
+
+        # Send actual client IP upstream
+        include proxy_params;
+
+        # backend
+        location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known|version|sitemap.xml) {
+            proxy_pass "http://$lemmy";
+
+            # Send actual client IP upstream
+            include proxy_params;
+        }
+    }
+
+    server {
+        set $lemmy_ui "lemmy-ui:1234";
+        # this is the port inside docker, not the public one yet
+        listen 1236;
+
+        ## CHANGE `sub.londerdomain.com` HERE
+        server_name sub.longerdomain.com;
+        server_tokens off;
+
+        # Upload limit, relevant for pictrs
+        client_max_body_size 20M;
+
+        # Send actual client IP upstream
+        include proxy_params;
+
+        # frontend general requests
+        location / {
+            proxy_pass $proxpass;
+            rewrite ^(.+)/+$ $1 permanent;
+        }
+
+        # security.txt
+        location = /.well-known/security.txt {
+            proxy_pass "http://$lemmy_ui";
+        }
+    }
+}

--- a/assets/separate_subdomains/traefik/compose.yml
+++ b/assets/separate_subdomains/traefik/compose.yml
@@ -36,32 +36,9 @@ services:
       - traefik.http.routers.lemmy-https.tls=true
       ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
       - traefik.http.routers.lemmy-https.tls.certresolver=myresolver
-  # This is the frontend which users will access
-  alexandrite:
-    image: ghcr.io/sheodox/alexandrite:latest
-    networks:
-      - proxy
-    labels:
-      - traefik.enable=true
-      - traefik.http.services.lemmy-ui.loadbalancer.server.port=3000
-      - traefik.http.services.lemmy-ui.loadbalancer.server.scheme=http
-      - traefik.http.routers.lemmy-ui-https.entrypoints=websecure
-      - traefik.http.routers.lemmy-ui-https.service=lemmy-ui
-      ## CHANGE `sub.londerdomain.com` HERE
-      - traefik.http.routers.lemmy-ui-https.rule=Host(`sub.longerdomain.com`)
-      - traefik.http.routers.lemmy-ui-https.tls=true
-      ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
-      - traefik.http.routers.lemmy-ui-https.tls.certresolver=myresolver
-    environment:
-      ## CHANGE `short.domain` HERE
-      - ALEXANDRITE_DEFAULT_INSTANCE=short.domain
-      - ALEXANDRITE_WELCOME_LEMMY_HELP=false
-      - ALEXANDRITE_WELCOME_INSTANCE_HELP=false
-      - ALEXANDRITE_FORCE_INSTANCE=short.domain
-  # This is the frontend where you can configure admin settings.
-  # This is optional.
+  # This is the Lemmy UI.
   lemmy-ui:
-    image: dessalines/lemmy-ui:0.19.10
+    # image: **UPDATE WITH THE FIXED LEMMY UI VERSION**
     environment:
       - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
       ## CHANGE `short.domain` HERE
@@ -77,16 +54,15 @@ services:
       - backend
     labels:
       - traefik.enable=true
-      - traefik.http.services.lemmy-admin-ui.loadbalancer.server.port=1234
-      - traefik.http.services.lemmy-admin-ui.loadbalancer.server.scheme=http
-      - traefik.http.routers.lemmy-admin-ui-https.entrypoints=websecure
-      - traefik.http.routers.lemmy-admin-ui-https.service=lemmy-admin-ui
-      ## CHANGE `short.domain` HERE
-      - traefik.http.routers.lemmy-admin-ui-https.rule=Host(`short.domain`) &&
-        PathPrefix(`/css`) || Host(`short.domain`) && PathPrefix(`/login`) || Host(`short.domain`) && PathPrefix(`/admin`)
-      - traefik.http.routers.lemmy-admin-ui-https.tls=true
+      - traefik.http.services.lemmy-ui.loadbalancer.server.port=1234
+      - traefik.http.services.lemmy-ui.loadbalancer.server.scheme=http
+      - traefik.http.routers.lemmy-ui-https.entrypoints=websecure
+      - traefik.http.routers.lemmy-ui-https.service=lemmy-ui
+      ## CHANGE `sub.longerdomain.com` HERE
+      - traefik.http.routers.lemmy-ui-https.rule=Host(`sub.longerdomain.com`)
+      - traefik.http.routers.lemmy-ui-https.tls=true
       ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
-      - traefik.http.routers.lemmy-admin-ui-https.tls.certresolver=myresolver
+      - traefik.http.routers.lemmy-ui-https.tls.certresolver=myresolver
     logging: *a1
   pictrs:
     image: asonix/pictrs:0.5.16

--- a/assets/separate_subdomains/traefik/compose.yml
+++ b/assets/separate_subdomains/traefik/compose.yml
@@ -1,0 +1,137 @@
+x-logging: &a1
+  driver: json-file
+  options:
+    max-size: 50m
+    max-file: "4"
+
+services:
+  lemmy:
+    image: dessalines/lemmy:0.19.10
+    hostname: lemmy
+    restart: always
+    logging: *a1
+    environment:
+      - RUST_LOG="warn"
+      # You can switch to the environment variable below to ensure federation is working correctly
+      # - RUST_LOG=lemmy_federate=trace
+    volumes:
+      # This volume mapping, and all others, should be configured to point to the correct location on your system
+      - ./lemmy.hjson:/config/config.hjson:Z
+    depends_on:
+      - postgres
+      - pictrs
+    # These should be changed to match your Traefik setup.
+    # Please refer to the "Placeholders" section in the documentation.
+    networks:
+      - proxy
+      - backend
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.lemmy.loadbalancer.server.port=8536
+      - traefik.http.services.lemmy.loadbalancer.server.scheme=http
+      - traefik.http.routers.lemmy-https.entrypoints=websecure
+      - traefik.http.routers.lemmy-https.service=lemmy
+      ## CHANGE `short.domain` HERE
+      - traefik.http.routers.lemmy-https.rule=Host(`short.domain`) && (PathPrefix(`/api`) || PathPrefix(`/pictrs`) || PathPrefix(`/feeds`) || PathPrefix(`/nodeinfo`) || PathPrefix(`/.well-known`) || PathPrefix(`/inbox`) || Path(`/version`) || Path(`/sitemap.xml`) || Method(`POST`) || HeaderRegexp(`Accept`,`^[Aa]pplication/.*`))
+      - traefik.http.routers.lemmy-https.tls=true
+      ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
+      - traefik.http.routers.lemmy-https.tls.certresolver=myresolver
+  # This is the frontend which users will access
+  alexandrite:
+    image: ghcr.io/sheodox/alexandrite:latest
+    networks:
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.lemmy-ui.loadbalancer.server.port=3000
+      - traefik.http.services.lemmy-ui.loadbalancer.server.scheme=http
+      - traefik.http.routers.lemmy-ui-https.entrypoints=websecure
+      - traefik.http.routers.lemmy-ui-https.service=lemmy-ui
+      ## CHANGE `sub.londerdomain.com` HERE
+      - traefik.http.routers.lemmy-ui-https.rule=Host(`sub.longerdomain.com`)
+      - traefik.http.routers.lemmy-ui-https.tls=true
+      ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
+      - traefik.http.routers.lemmy-ui-https.tls.certresolver=myresolver
+    environment:
+      ## CHANGE `short.domain` HERE
+      - ALEXANDRITE_DEFAULT_INSTANCE=short.domain
+      - ALEXANDRITE_WELCOME_LEMMY_HELP=false
+      - ALEXANDRITE_WELCOME_INSTANCE_HELP=false
+      - ALEXANDRITE_FORCE_INSTANCE=short.domain
+  # This is the frontend where you can configure admin settings.
+  # This is optional.
+  lemmy-ui:
+    image: dessalines/lemmy-ui:0.19.10
+    environment:
+      - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
+      ## CHANGE `short.domain` HERE
+      - LEMMY_UI_LEMMY_EXTERNAL_HOST=short.domain
+      - LEMMY_UI_HTTPS=true
+    volumes:
+      - ./volumes/lemmy-ui/extra_themes:/app/extra_themes
+    depends_on:
+      - lemmy
+    restart: always
+    networks:
+      - proxy
+      - backend
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.lemmy-admin-ui.loadbalancer.server.port=1234
+      - traefik.http.services.lemmy-admin-ui.loadbalancer.server.scheme=http
+      - traefik.http.routers.lemmy-admin-ui-https.entrypoints=websecure
+      - traefik.http.routers.lemmy-admin-ui-https.service=lemmy-admin-ui
+      ## CHANGE `short.domain` HERE
+      - traefik.http.routers.lemmy-admin-ui-https.rule=Host(`short.domain`) &&
+        PathPrefix(`/css`) || PathPrefix(`/login`) || PathPrefix(`/admin`)
+      - traefik.http.routers.lemmy-admin-ui-https.tls=true
+      ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
+      - traefik.http.routers.lemmy-admin-ui-https.tls.certresolver=myresolver
+    logging: *a1
+  pictrs:
+    image: asonix/pictrs:0.5.16
+    # This needs to match the pictrs url in lemmy.hjson
+    hostname: pictrs
+    # We can set options to pictrs like this, here we set max. image size and forced format for conversion
+    # entrypoint: /sbin/tini -- /usr/local/bin/pict-rs -p /mnt -m 4 --image-format webp
+    environment:
+      - PICTRS_OPENTELEMETRY_URL=http://otel:4137
+      ## SET YOUR POSTGRES PASSWORD HERE
+      - PICTRS__SERVER__API_KEY={{ postgres_password }}
+      - RUST_BACKTRACE=full
+      - PICTRS__MEDIA__VIDEO__VIDEO_CODEC=vp9
+      - PICTRS__MEDIA__ANIMATION__MAX_WIDTH=256
+      - PICTRS__MEDIA__ANIMATION__MAX_HEIGHT=256
+      - PICTRS__MEDIA__ANIMATION__MAX_FRAME_COUNT=400
+    user: 991:991
+    volumes:
+      - ./volumes/pictrs:/mnt:Z
+    restart: always
+    networks:
+      - backend
+    logging: *a1
+  postgres:
+    image: pgautoupgrade/pgautoupgrade:17-alpine
+    hostname: postgres
+    environment:
+      - POSTGRES_USER=lemmy
+      ## SET YOUR POSTGRES PASSWORD HERE
+      - POSTGRES_PASSWORD={{ postgres_password }}
+      - POSTGRES_DB=lemmy
+    # This should match the `shared_buffers` setting in customPostgresql.conf
+    shm_size: 1g
+    volumes:
+      - ./volumes/postgres:/var/lib/postgresql/data:Z
+      - ./customPostgresql.conf:/etc/postgresql.conf
+    restart: always
+    networks:
+      - backend
+    logging: *a1
+
+# Network configuration
+# Change this to match your setup
+networks:
+  proxy:
+    external: true
+  backend:
+    external: true

--- a/assets/separate_subdomains/traefik/compose.yml
+++ b/assets/separate_subdomains/traefik/compose.yml
@@ -83,7 +83,7 @@ services:
       - traefik.http.routers.lemmy-admin-ui-https.service=lemmy-admin-ui
       ## CHANGE `short.domain` HERE
       - traefik.http.routers.lemmy-admin-ui-https.rule=Host(`short.domain`) &&
-        PathPrefix(`/css`) || PathPrefix(`/login`) || PathPrefix(`/admin`)
+        PathPrefix(`/css`) || Host(`short.domain`) && PathPrefix(`/login`) || Host(`short.domain`) && PathPrefix(`/admin`)
       - traefik.http.routers.lemmy-admin-ui-https.tls=true
       ## CHANGE `myresolver` TO BE YOUR TLS CERT RESOLVER
       - traefik.http.routers.lemmy-admin-ui-https.tls.certresolver=myresolver

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Troubleshooting](administration/troubleshooting.md)
 - [Backup and Restore](administration/backup_and_restore.md)
 - [Using Caddy as a reverse proxy](administration/caddy.md)
+- [Lemmy on Separate Subdomains](administration/separate_subdomains.md)
 - [Running a Tor Hidden Service](administration/tor_hidden_service.md)
 - [Prometheus Metrics](administration/prometheus.md)
 - [Horizontal Scaling](administration/horizontal_scaling.md)

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -13,12 +13,7 @@ As a general overview, this works by handling federation requests on the short d
 
 ## Limitations
 
-- As of the time of writing this (March 25th, 2025), the Lemmy UI seems to be hardcoded to the domain on which it is hosted. For example, even if you set the `LEMMY_UI_LEMMY_EXTERNAL_HOST` environment variable to be `short.domain`, the UI will still try accessing `sub.longerdomain.com` for API requests.
-
-In theory, if this is changed in the future, this documentation will be updated to reflect the change. However, in practice that may not occur. If you are reading this page far into the future, it may be worthwhile to test this functionality again to see if it has been changed.
-
 - If there is another service using the `/api`, `/pictrs`, `/feeds`, `/nodeinfo`, `/.well-known`, `/inbox`, `/version`, and `/sitemap.xml` paths on `short.domain`, it will conflict with the Lemmy server. Similarly, if there is a service on `short.domain` listening for the `Accept: application/activity+json` HTTP header, it will also conflict with the Lemmy server.
-- If you still want to access the admin user interface, the paths `/login` and `/admin` will also need to be unused on `short.domain`. This is optional, however, and is not required if the `lemmy-ui` container is omitted.
 
 ## Traefik
 

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -1,6 +1,6 @@
 # Lemmy on Separate Subdomains
 
-This guide details hosting the Lemmy backend and frontend on diffrent domains. This is useful, for example, if you want users to have a webfinger (user handle) without a subdomain, but want to host services on the same domain.
+This guide details hosting the Lemmy backend and frontend on different domains. This is useful, for example, if you want users to have a webfinger (user handle) without a subdomain, but want to host services on the same domain.
 
 ## Placeholders
 
@@ -16,7 +16,7 @@ This guide details hosting the Lemmy backend and frontend on diffrent domains. T
 In theory, if this is changed in the future, this documentation will be updated to reflect the change. However, in practice that may not occur. If you are reading this page far into the future, it may be worthwhile to test this functionality again to see if it has been changed.
 
 - If there is another service using the `/api`, `/pictrs`, `/feeds`, `/nodeinfo`, `/.well-known`, `/inbox`, `/version`, and `/sitemap.xml` paths on `short.domain`, it will conflict with the Lemmy server. Similarly, if there is a service on `short.domain` listening for the `Accept: application/activity+json` HTTP header, it will also conflict with the Lemmy server.
-- If you still want to access the admin user interface, the paths `/login` and `/admin` will also need to be unused on `short.domain`. This is optional, however, and is not required if the `lemmy-ui` container is ommitted.
+- If you still want to access the admin user interface, the paths `/login` and `/admin` will also need to be unused on `short.domain`. This is optional, however, and is not required if the `lemmy-ui` container is omitted.
 
 ## Traefik
 

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -40,4 +40,6 @@ You can download the `nginx_internal.conf` file by running:
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-docs/main/assets/separate_subdomains/nginx/nginx_internal.conf
 ```
 
+Ensure you edit `nginx_internal.conf` and replace `{{ nginx_internal_resolver }}` with `127.0.0.11` (use `10.89.0.1` for RedHat distributions).
+
 Then continue installing with your preferred installation method. For example, [these are the Docker instructions](https://join-lemmy.org/docs/administration/install_docker.html). Ensure you use the `nginx_internal.conf` file provided on this page.

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -11,7 +11,7 @@ This guide details hosting the Lemmy backend and frontend on diffrent domains. T
 
 ## Limitations
 
-- As of the time of writing this (March 25th, 2025), the Lemmy UI seems to be hardcoded to the domain on which it is hosted. For example, even if you set the `LEMMY_UI_LEMMY_EXTERNAL_HOST` environment variable to be `short.domain`, the UI will still try accessing `sub.longerdomain.com`.
+- As of the time of writing this (March 25th, 2025), the Lemmy UI seems to be hardcoded to the domain on which it is hosted. For example, even if you set the `LEMMY_UI_LEMMY_EXTERNAL_HOST` environment variable to be `short.domain`, the UI will still try accessing `sub.longerdomain.com` for API requests.
 
 In theory, if this is changed in the future, this documentation will be updated to reflect the change. However, in practice that may not occur. If you are reading this page far into the future, it may be worthwhile to test this functionality again to see if it has been changed.
 

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -3,12 +3,14 @@
 This guide details hosting the Lemmy backend and frontend on diffrent domains. This is useful, for example, if you want users to have a webfinger (user handle) without a subdomain, but want to host services on the same domain.
 
 ## Placeholders
+
 - `short.domain` represents the shortened domain you would like to use for user handles.
 - `sub.longerdomain.com` represents the domain where the UI will be served.
 - The `proxy` network is the configured Traefik network, and is only referenced in the Traefik configuration. Please see the [Traefik documentation](https://doc.traefik.io/traefik/providers/docker/#network).
 - The `backend` network is the network used to communicate between Docker containers. This is only referenced in the Traefik configuration. This can be renamed to your liking. In the configuration, this is referenced as an `external` Docker network, but can also be an `internal` Docker network ([documentation here](https://docs.docker.com/compose/how-tos/networking/#use-a-pre-existing-network)).
 
 ## Limitations
+
 - As of the time of writing this (March 25th, 2025), the Lemmy UI seems to be hardcoded to the domain on which it is hosted. For example, even if you set the `LEMMY_UI_LEMMY_EXTERNAL_HOST` environment variable to be `short.domain`, the UI will still try accessing `sub.longerdomain.com`.
 
 In theory, if this is changed in the future, this documentation will be updated to reflect the change. However, in practice that may not occur. If you are reading this page far into the future, it may be worthwhile to test this functionality again to see if it has been changed.
@@ -17,9 +19,11 @@ In theory, if this is changed in the future, this documentation will be updated 
 - If you still want to access the admin user interface, the paths `/login` and `/admin` will also need to be unused on `short.domain`. This is optional, however, and is not required if the `lemmy-ui` container is ommitted.
 
 ## Traefik
+
 This is the solution that is currently being tested (by this author). Federation is not a problem whatsoever, and everything is working correctly.
 
 You can download the Docker Compose file by running:
+
 ```sh
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-docs/main/assets/separate_subdomains/traefik/compose.yml
 ```
@@ -31,6 +35,7 @@ Then continue the [Docker instructions here](https://join-lemmy.org/docs/adminis
 This solution is derived from the Traefik configuration above. Please note, some configuration options may be unnecessary due to the fact that this was derived from a Traefik configuration. Feel free to open a [pull request](https://github.com/LemmyNet/lemmy-docs).
 
 You can download the `nginx_internal.conf` file by running:
+
 ```sh
 wget https://raw.githubusercontent.com/LemmyNet/lemmy-docs/main/assets/separate_subdomains/nginx/nginx_internal.conf
 ```

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -1,0 +1,38 @@
+# Lemmy on Separate Subdomains
+
+This guide details hosting the Lemmy backend and frontend on diffrent domains. This is useful, for example, if you want users to have a webfinger (user handle) without a subdomain, but want to host services on the same domain.
+
+## Placeholders
+- `short.domain` represents the shortened domain you would like to use for user handles.
+- `sub.longerdomain.com` represents the domain where the UI will be served.
+- The `proxy` network is the configured Traefik network, and is only referenced in the Traefik configuration. Please see the [Traefik documentation](https://doc.traefik.io/traefik/providers/docker/#network).
+- The `backend` network is the network used to communicate between Docker containers. This is only referenced in the Traefik configuration. This can be renamed to your liking. In the configuration, this is referenced as an `external` Docker network, but can also be an `internal` Docker network ([documentation here](https://docs.docker.com/compose/how-tos/networking/#use-a-pre-existing-network)).
+
+## Limitations
+- As of the time of writing this (March 25th, 2025), the Lemmy UI seems to be hardcoded to the domain on which it is hosted. For example, even if you set the `LEMMY_UI_LEMMY_EXTERNAL_HOST` environment variable to be `short.domain`, the UI will still try accessing `sub.longerdomain.com`.
+
+In theory, if this is changed in the future, this documentation will be updated to reflect the change. However, in practice that may not occur. If you are reading this page far into the future, it may be worthwhile to test this functionality again to see if it has been changed.
+
+- If there is another service using the `/api`, `/pictrs`, `/feeds`, `/nodeinfo`, `/.well-known`, `/inbox`, `/version`, and `/sitemap.xml` paths on `short.domain`, it will conflict with the Lemmy server. Similarly, if there is a service on `short.domain` listening for the `Accept: application/activity+json` HTTP header, it will also conflict with the Lemmy server.
+- If you still want to access the admin user interface, the paths `/login` and `/admin` will also need to be unused on `short.domain`. This is optional, however, and is not required if the `lemmy-ui` container is ommitted.
+
+## Traefik
+This is the solution that is currently being tested (by this author). Federation is not a problem whatsoever, and everything is working correctly.
+
+You can download the Docker Compose file by running:
+```sh
+wget https://raw.githubusercontent.com/LemmyNet/lemmy-docs/main/assets/separate_subdomains/traefik/compose.yml
+```
+
+Then continue the [Docker instructions here](https://join-lemmy.org/docs/administration/install_docker.html), excluding the NGINX steps.
+
+## NGINX
+
+This solution is derived from the Traefik configuration above. Please note, some configuration options may be unnecessary due to the fact that this was derived from a Traefik configuration. Feel free to open a [pull request](https://github.com/LemmyNet/lemmy-docs).
+
+You can download the `nginx_internal.conf` file by running:
+```sh
+wget https://raw.githubusercontent.com/LemmyNet/lemmy-docs/main/assets/separate_subdomains/nginx/nginx_internal.conf
+```
+
+Then continue installing with your preferred installation method. For example, [these are the Docker instructions](https://join-lemmy.org/docs/administration/install_docker.html). Ensure you use the `nginx_internal.conf` file provided on this page.

--- a/src/administration/separate_subdomains.md
+++ b/src/administration/separate_subdomains.md
@@ -2,6 +2,8 @@
 
 This guide details hosting the Lemmy backend and frontend on different domains. This is useful, for example, if you want users to have a webfinger (user handle) without a subdomain, but want to host services on the same domain.
 
+As a general overview, this works by handling federation requests on the short domain and forwarding them to the Lemmy backend. API and frontend requests however are handled on the long domain.
+
 ## Placeholders
 
 - `short.domain` represents the shortened domain you would like to use for user handles.


### PR DESCRIPTION
As discussed in the [Lemmy Matrix chat](https://matrix.to/#/#lemmy-support-general:discuss.online), this PR adds documentation for running the Lemmy backend and frontend on separate subdomains.

# Important
The Traefik configuration has been tested, however I am unable to test the NGINX configuration. If possible, it would be great if someone could test it.

# Notes
- This PR references a third-party Docker container (for the UI) which is required for this configuration.

Please let me know if there are any issues! I'm always hoping for constructive feedback.