### PR TITLE
Added documentation for code formatting tools (ref #370)

### DIFF
--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -75,6 +75,32 @@ psql -c 'create database lemmy with owner lemmy;' -U postgres
 export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432/lemmy
 ```
 
+### Code formatting tools
+
+#### Taplo
+See installation instructions [here](https://taplo.tamasfe.dev/), or run
+```bash
+cargo install taplo-cli --locked
+```
+
+#### pg_format
+
+Debian-based distro:
+
+```bash
+sudo apt install pgformatter
+```
+Arch-based distro:
+
+```bash
+sudo pacman -S pgformatter
+```
+macOS:
+
+```bash
+brew install pgformatter
+```
+
 ### Get the code
 
 Clone frontend and backend code to local folders. Be sure to include `--recursive` to initialize git submodules.

--- a/src/contributors/02-local-development.md
+++ b/src/contributors/02-local-development.md
@@ -78,7 +78,9 @@ export LEMMY_DATABASE_URL=postgres://lemmy:password@localhost:5432/lemmy
 ### Code formatting tools
 
 #### Taplo
+
 See installation instructions [here](https://taplo.tamasfe.dev/), or run
+
 ```bash
 cargo install taplo-cli --locked
 ```
@@ -90,11 +92,13 @@ Debian-based distro:
 ```bash
 sudo apt install pgformatter
 ```
+
 Arch-based distro:
 
 ```bash
 sudo pacman -S pgformatter
 ```
+
 macOS:
 
 ```bash


### PR DESCRIPTION
Reference: #370
Added installation steps for [taplo](https://taplo.tamasfe.dev/) and [pgformatter](https://github.com/darold/pgformatter).
The second one has very convoluted installation guide on its github page, so I added 3 separate commands for different packet managers. Tested only on ubuntu, but found that the package name is the same on [arch](https://archlinux.org/packages/extra/any/pgformatter/) and [mac](https://formulae.brew.sh/formula/pgformatter).
Decided to put them to a separate section, since these tools are not essential for contribution.