### PR TITLE
Substitute LEMMY_UI_LEMMY_EXTERNAL_HOST in Compose

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     image: dessalines/lemmy-ui:0.19.12
     environment:
       - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
-      - LEMMY_UI_LEMMY_EXTERNAL_HOST=lemmy.ml
+      - LEMMY_UI_LEMMY_EXTERNAL_HOST={{ domain }}
       - LEMMY_UI_HTTPS=true
     volumes:
       - ./volumes/lemmy-ui/extra_themes:/app/extra_themes


### PR DESCRIPTION
Currently, the `LEMMY_UI_LEMMY_EXTERNAL_HOST` is hardcoded to lemmy.ml. Updating to be a var substitution to `{{ domain }}` like how the docs mention.

Problem originally found at: https://ponder.cat/post/3716662