### PR TITLE
fix: volume path for PostgreSQL in docker-compose

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - POSTGRES_DB=lemmy
     shm_size: 1g
     volumes:
-      - ./volumes/postgres:/var/lib/postgresql/data:Z
+      - ./volumes/postgres:/var/lib/postgresql:Z
       - ./customPostgresql.conf:/etc/postgresql.conf
     restart: always
     logging: *default-logging


### PR DESCRIPTION
Attempting to deploy with the current docker-compose yielded:
> Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/.../postgres" to rootfs at "/var/lib/postgresql/data": change mount propagation through procfd: open o_path procfd: open /var/lib/docker/overlay2/.../merged/var/lib/postgresql/data: no such file or directory: unknown

With pgautougrade v18, the mount point has changed:

> Then you have to adjust your volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`. `pgautoupgrade` will look there for an old Postgres installation, and move the data into the new expected structure.

> Root cause is https://github.com/docker-library/postgres/pull/1259 that enforces a new data directory structure with Postgres v18+. Previously, your Postgres data and the corresponding PGDATA pointed to `/var/lib/postgresql/data`. With Postgres v18+, it is `/var/lib/postgresql/MAJOR/docker`. The Docker team also placed a symlink from `/var/lib/postgresql/data` to `/var/lib/postgresql` causing the error messages above.

https://github.com/pgautoupgrade/docker-pgautoupgrade/blob/main/README.md#error-message-when-mounting-data-to-varlibpostgresqldata-on-postgres-v18